### PR TITLE
Remove function-calc-no-invalid

### DIFF
--- a/config.js
+++ b/config.js
@@ -32,7 +32,6 @@ module.exports = {
         'max-nesting-depth': 4,
         'selector-max-specificity': '0,4,0',
         'value-no-vendor-prefix': true,
-        'function-calc-no-invalid': true,
         'property-no-vendor-prefix': true,
         'selector-no-vendor-prefix': true,
         'media-feature-name-no-vendor-prefix': true,


### PR DESCRIPTION
This PR removes the rule `function-calc-no-invalid`.

`function-calc-no-invalid` was removed in [stylelint 14](https://github.com/stylelint/stylelint/releases/tag/14.0.0)

When using this config on projects that use stylelint>14, we get an error "Unknown rule function-calc-no-invalid".